### PR TITLE
Fix duree mois chaine vide

### DIFF
--- a/scripts/sources/marches-publics.info/fix.jq
+++ b/scripts/sources/marches-publics.info/fix.jq
@@ -16,7 +16,7 @@ def walk(f):
 
 .marches[].montant |= if type == "string" then tonumber else . end |
 .marches[].valeurGlobale |= if type == "string" then tonumber else . end |
-.marches[].dureeMois |= if type == "string" then tonumber | ceil(.) else ceil(.) end |
+.marches[].dureeMois |= if (type == "string" and length > 0) then tonumber | ceil(.) elif (type == "number") then ceil(.) else 1 end |
 .marches[].lieuExecution.code |= if type == "number" then tostring else . end |
 .marches[].lieuExecution.nom |= if type == "number" then tostring else . end |
 .marches[].id |= if type == "number" then tostring else . end |


### PR DESCRIPTION

Bonjour,

J'ai cloturé l'autre PR sur ce problème car je m'étais trompé en poussant un peu vite sur la mauvaise branche...
Du coup, je remets le contenu de la PR avec uniquement le fix du problème :

Erreur sur certains fichiers au moment de l'exécution de l'étape "fix" :

```
Correction de aws-marchespublics-annee-2019.json...
jq: error (at ./original-data/aws-marchespublics-annee-2019.json:3654667): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2020.json...
jq: error (at ./original-data/aws-marchespublics-annee-2020.json:4097946): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2021.json...
jq: error (at ./original-data/aws-marchespublics-annee-2021.json:3569669): Expected JSON value (while parsing '')
```

Cela est dû à la propriété dureeMois qui est vide dans quelques rares cas. Exemple Marché ID 201933PA04 de aws-marchespublics-annee-2019.json :

      "dureeMois": "",

**Important** : Dans cette PR, je mets la valeur par défaut à 1 dans le cas où on n'arrive pas à détecter un nombre sur la propriété dureeMois. Valeur totalement arbitraire car je n'ai pas trouvé de "valeur par défaut" pour ce champ dans le reste du projet...
