### PR TITLE
Fix #102 source region bretagne

### DIFF
--- a/scripts/sources/region-bretagne/convert.sh
+++ b/scripts/sources/region-bretagne/convert.sh
@@ -10,7 +10,8 @@ mkdir -p $DECP_HOME/json/$source
 
 for xml in *.xml
 do
-
+#fix xml malformes contenant des &
+sed -i 's/&/&amp;/g' $xml
 #Convertit le XML DECP vers JSON DECP
 $DECP_HOME/scripts/xmlDECP2jsonDECP.sh $xml > $DECP_HOME/json/$source/$xml.json
 done

--- a/scripts/sources/region-bretagne/get.sh
+++ b/scripts/sources/region-bretagne/get.sh
@@ -4,4 +4,11 @@
 # Récupération des données
 
 
-wget -q -O decp2021_regionbretagne.xml https://data.bretagne.bzh/api/datasets/1.0/decp-crb/alternative_exports/decp2021_regionbretagne_csv_xml
+echo "Telechargement region bretagne 2019"
+wget -q -O decp2019_regionbretagne.xml https://data.bretagne.bzh/api/datasets/1.0/decp-crb0/alternative_exports/2019_decp_crb_xml
+echo "Telechargement region bretagne 2020"
+wget -q -O decp2020_regionbretagne.xml https://data.bretagne.bzh/api/datasets/1.0/decp-crb0/alternative_exports/2020_decp_crb_xml
+echo "Telechargement region bretagne 2021"
+wget -q -O decp2021_regionbretagne.xml https://data.bretagne.bzh/api/datasets/1.0/decp-crb0/alternative_exports/2021_decp_crb_xml
+echo "Telechargement region bretagne 2022"
+wget -q -O decp2022_regionbretagne.xml https://data.bretagne.bzh/api/datasets/1.0/decp-crb0/alternative_exports/2022_decp_crb_xml


### PR DESCRIPTION
Fix pour région Bretagne car les sources ont changé (voir #102 )

J'ai remarqué qu'on ne récupérait qu'une seule année alors qu'on avait plusieurs années de dispos sur le site opendata de region bretagne. J'ai donc rajouté ces sources aussi. Sauf que le XML de l'année 2022 est malformé, il contenait des "&" au lieu de `&amp;` ce qui rend le XML invalide d'où le petit rajout du "sed" dans le fichier convert.sh

cc @ColinMaudry

Edit : liste des exports visibles ici : https://data.bretagne.bzh/explore/dataset/decp-crb0/export/